### PR TITLE
Use List/Tuple from typing for type hints

### DIFF
--- a/onnxsharp/graph.py
+++ b/onnxsharp/graph.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import List, Tuple
 from black import validate_cell
 import onnx
 from onnx import helper, defs, numpy_helper, checker
@@ -98,7 +99,7 @@ class Graph(object):
         )
         return self._initializer_map[output_arg_name]
 
-    def get_node_with_output_arg_name(self, output_arg_name: str) -> tuple[Node, int]:
+    def get_node_with_output_arg_name(self, output_arg_name: str) -> Tuple[Node, int]:
         enforce(output_arg_name is not None, "output_arg_name should not be None")
         enforce(
             output_arg_name in self._output_arg_name_to_node_mapping,
@@ -308,8 +309,8 @@ class Graph(object):
         self,
         type: str,
         name: str,
-        input_arg_names: list[str],
-        output_arg_names: list[str],
+        input_arg_names: List[str],
+        output_arg_names: List[str],
         domain: str,
         doc_string: str,
         **kwargs,

--- a/onnxsharp/graph_utils.py
+++ b/onnxsharp/graph_utils.py
@@ -1,11 +1,11 @@
-from typing import OrderedDict
+from typing import List, OrderedDict
 from onnxsharp import Model, Graph, Node, ValueInfo, NodeArg
 from .basics import enforce
 import copy
 import re
 
 
-def topological_sort(graph, ops: list[Node]) -> list[Node]:
+def topological_sort(graph, ops: List[Node]) -> List[Node]:
     """Topological sort of graph."""
     # sort by name, the result will be reversed alphabeta
     ops.sort(key=lambda op: op.name)

--- a/onnxsharp/node.py
+++ b/onnxsharp/node.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import List
 from black import validate_cell
 import onnx
 from onnx import helper, defs, numpy_helper, checker
@@ -277,7 +278,7 @@ class Node(object):
         return self._type
 
     @property
-    def output_arg_names(self) -> list[str]:
+    def output_arg_names(self) -> List[str]:
         return [arg.name for arg in self._output_args]
 
     def output_arg(self, index):
@@ -288,7 +289,7 @@ class Node(object):
         return self._output_args[index]
 
     @property
-    def input_arg_names(self) -> list[str]:
+    def input_arg_names(self) -> List[str]:
         return [arg.name for arg in self._input_args]
 
     def input_arg(self, index):


### PR DESCRIPTION
Type hints using standard collections like `list`/`tuple` is supported since Python 3.9. Change it to use `List`/`Tuple` from `typing` module for compatibility. (Since Python 3.7, using `from __future__ import annotations` will also support standard collections for type hints.)